### PR TITLE
Conditionally disable comment actions on forked repo PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,8 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -66,6 +66,7 @@ jobs:
           echo '' >> comment_body.md
           echo '```' >> comment_body.md
       - name: Find Coverage Report Comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
         id: find-comment
         uses: peter-evans/find-comment@v3
         with:
@@ -73,6 +74,7 @@ jobs:
           comment-author: github-actions[bot]
           body-includes: '### Coverage Report'
       - name: Create or Update Coverage Comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -80,3 +82,9 @@ jobs:
           body-path: comment_body.md
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
+      - name: Display Coverage Report in Logs
+        run: |
+          echo "### Coverage Report"
+          echo "-------------------"
+          cat comment_body.md
+          echo "-------------------"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -83,8 +83,4 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
       - name: Display Coverage Report in Logs
-        run: |
-          echo "### Coverage Report"
-          echo "-------------------"
-          cat comment_body.md
-          echo "-------------------"
+        run: cat comment_body.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,8 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.2.2
+    hooks:
+    - id: zizmor
+      args: [ --min-severity, low, --min-confidence, medium]


### PR DESCRIPTION
Added zizmor GitHub action linter and conditionally disable comment actions on forked repo PRs.

I read I could change the action trigger to: _pull_request_target_ to allow forked PRs to run with the same permissions as local PRs but apparently that opens the workflows up to all sorts of possible exploits... which is a shame given I liked my action that could comment the PR with the test coverage.