### PR TITLE
Updated README to cover conda-forge installation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         additional_dependencies:
           - pydantic
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.9.5
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
@@ -49,7 +49,7 @@ repos:
           # --write-changes (Don't use this to stop typos making auto-corrections)
         ]
   - repo: https://github.com/owenlamont/uv-secure
-    rev: 0.8.0
+    rev: 0.8.1
     hooks:
       - id: uv-secure
   - repo: https://github.com/adrienverge/yamllint.git
@@ -57,7 +57,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.3.0
+    rev: v1.3.1
     hooks:
     - id: zizmor
       args: [ --min-severity, low, --min-confidence, medium]

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ refining the command line arguments and configuration behaviour.
 uv-secure is available on [PyPi](https://pypi.org/project/uv-secure/) and
 [conda-forge](https://anaconda.org/conda-forge/uv-secure).
 
-I recommend installing uv-secure as a uv tool or with pipx as it's intended to be used
-as a CLI tool, and it probably only makes sense to have one version installed globally.
+I recommend installing uv-secure as a uv tool, or with pipx, or as a pixi global tool as
+it's intended to be used as a CLI tool, and it probably only makes sense to have one
+version installed globally.
 
 Installing with uv tool as follows:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ refining the command line arguments and configuration behaviour.
 
 ## Installation
 
+uv-secure is available on [PyPi](https://pypi.org/project/uv-secure/) and
+[conda-forge](https://anaconda.org/conda-forge/uv-secure).
+
 I recommend installing uv-secure as a uv tool or with pipx as it's intended to be used
 as a CLI tool, and it probably only makes sense to have one version installed globally.
 
@@ -40,6 +43,12 @@ or with pipx:
 
 ```shell
 pipx install uv-secure
+```
+
+or from conda-forge with pixi:
+
+```shell
+pixi global install uv-secure
 ```
 
 you can optionally install uv-secure as a development dependency in a virtual


### PR DESCRIPTION
Now uv-secure is on conda-forge I wanted to add instructions for installing with pixi