### PR TITLE
chore: refresh .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: markdownlint
         args: [--fix]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v1.16.1
     hooks:
       - id: mypy
         additional_dependencies:
           - pydantic
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.0
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
@@ -49,7 +49,7 @@ repos:
           # --write-changes (Don't use this to stop typos making auto-corrections)
         ]
   - repo: https://github.com/owenlamont/uv-secure
-    rev: 0.9.1
+    rev: 0.9.2
     hooks:
       - id: uv-secure
   - repo: https://github.com/adrienverge/yamllint.git


### PR DESCRIPTION
This PR updates `.pre-commit-config.yaml` by running `pre-commit autoupdate`.
It was triggered automatically (or manually) to keep linters up-to-date.