### PR TITLE
chore: rename refresh job in update linters workflow

### DIFF
--- a/.github/workflows/update_linters.yml
+++ b/.github/workflows/update_linters.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  refresh-uv-lock:
+  refresh-pre-commit-config:
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Fixing minor copy paste name issue