### PR TITLE
chore: refresh .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         additional_dependencies:
           - pydantic
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.12.1
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
@@ -57,7 +57,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
     - id: zizmor
       args: [ --min-severity, low, --min-confidence, medium]


### PR DESCRIPTION
This PR updates `.pre-commit-config.yaml` by running `pre-commit autoupdate`.
It was triggered automatically (or manually) to keep linters up-to-date.