### PR TITLE
36 Ignore packages by name / version specifiers

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         extra: ["none", "faster-async"]
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba
       - run: uv build
       - name: Smoke test (wheel)
-        run: uv run --isolated --no-project -p 3.9 --with dist/*.whl tests/smoke_test.py
+        run: uv run --isolated --no-project -p 3.10 --with dist/*.whl tests/smoke_test.py
       - name: Smoke test (source distribution)
-        run: uv run --isolated --no-project -p 3.9 --with dist/*.tar.gz tests/smoke_test.py
+        run: uv run --isolated --no-project -p 3.10 --with dist/*.tar.gz tests/smoke_test.py
       - run: uv publish --trusted-publishing always

--- a/.gitignore
+++ b/.gitignore
@@ -164,4 +164,4 @@ cython_debug/
 .idea/
 
 # VS Code
-.code/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ servers. See roadmap below for my plans for future enhancements.
 
 I don't intend uv-secure to ever create virtual environments or do dependency
 resolution - the plan is to leave that all to uv since it does that so well and just
-target lock files and fully pinned and dependency resolved requirements.txt files). If
+target lock files and fully pinned and (dependency resolved) requirements.txt files. If
 you want a tool that does dependency resolution on requirements.txt files for first
 order and unpinned dependencies I recommend using
 [pip-audit](https://pypi.org/project/pip-audit/) instead.
@@ -113,50 +113,60 @@ After installation, you can run uv-secure --help to see the options.
 │                                    [default: None]                                   │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────╮
-│ --aliases                                           Flag whether to include          │
-│                                                     vulnerability aliases in the     │
-│                                                     vulnerabilities table            │
-│ --desc                                              Flag whether to include          │
-│                                                     vulnerability detailed           │
-│                                                     description in the               │
-│                                                     vulnerabilities table            │
-│ --cache-path                               PATH     Path to the cache directory for  │
-│                                                     vulnerability http requests      │
-│                                                     [default: (~/.cache/uv-secure)]  │
-│ --cache-ttl-seconds                        FLOAT    Time to live in seconds for the  │
-│                                                     vulnerability http requests      │
-│                                                     cache                            │
-│                                                     [default: 86400.0]               │
-│ --disable-cache                                     Flag whether to disable caching  │
-│                                                     for vulnerability http requests  │
-│ --forbid-yanked                                     Flag whether disallow yanked     │
-│                                                     package versions from being      │
-│                                                     dependencies                     │
-│ --max-age-days                             INTEGER  Maximum age threshold for        │
-│                                                     packages in days                 │
-│                                                     [default: None]                  │
-│ --ignore                           -i      TEXT     Comma-separated list of          │
-│                                                     vulnerability IDs to ignore,     │
-│                                                     e.g. VULN-123,VULN-456           │
-│                                                     [default: None]                  │
-│ --check-direct-dependency-vulner…                   Flag whether to only test only   │
-│                                                     direct dependencies for          │
-│                                                     vulnerabilities                  │
-│ --check-direct-dependency-mainte…                   Flag whether to only test only   │
-│                                                     direct dependencies for          │
-│                                                     maintenance issues               │
-│ --config                                   PATH     Optional path to a configuration │
-│                                                     file (uv-secure.toml,            │
-│                                                     .uv-secure.toml, or              │
-│                                                     pyproject.toml)                  │
-│                                                     [default: None]                  │
-│ --version                                           Show the application's version   │
-│ --install-completion                                Install completion for the       │
-│                                                     current shell.                   │
-│ --show-completion                                   Show completion for the current  │
-│                                                     shell, to copy it or customize   │
-│                                                     the installation.                │
-│ --help                                              Show this message and exit.      │
+│ --aliases                                               Flag whether to include      │
+│                                                         vulnerability aliases in the │
+│                                                         vulnerabilities table        │
+│ --desc                                                  Flag whether to include      │
+│                                                         vulnerability detailed       │
+│                                                         description in the           │
+│                                                         vulnerabilities table        │
+│ --cache-path                         PATH               Path to the cache directory  │
+│                                                         for vulnerability http       │
+│                                                         requests                     │
+│                                                         [default:                    │
+│                                                         (~/.cache/uv-secure)]        │
+│ --cache-ttl-seconds                  FLOAT              Time to live in seconds for  │
+│                                                         the vulnerability http       │
+│                                                         requests cache               │
+│                                                         [default: 86400.0]           │
+│ --disable-cache                                         Flag whether to disable      │
+│                                                         caching for vulnerability    │
+│                                                         http requests                │
+│ --forbid-yanked                                         Flag whether disallow yanked │
+│                                                         package versions from being  │
+│                                                         dependencies                 │
+│ --max-age-days                       INTEGER            Maximum age threshold for    │
+│                                                         packages in days             │
+│                                                         [default: None]              │
+│ --ignore-vulns                       TEXT               Comma-separated list of      │
+│                                                         vulnerability IDs to ignore, │
+│                                                         e.g. VULN-123,VULN-456       │
+│                                                         [default: None]              │
+│ --ignore-pkgs                        PKG:SPEC1|SPEC2|…  Dependency with optional     │
+│                                                         version specifiers. Syntax:  │
+│                                                         name:spec1|spec2|…  e.g.     │
+│                                                         foo:>=1.0,<1.5|==4.5.*       │
+│                                                         [default: None]              │
+│ --check-direct-dependency-vu…                           Flag whether to only test    │
+│                                                         only direct dependencies for │
+│                                                         vulnerabilities              │
+│ --check-direct-dependency-ma…                           Flag whether to only test    │
+│                                                         only direct dependencies for │
+│                                                         maintenance issues           │
+│ --config                             PATH               Optional path to a           │
+│                                                         configuration file           │
+│                                                         (uv-secure.toml,             │
+│                                                         .uv-secure.toml, or          │
+│                                                         pyproject.toml)              │
+│                                                         [default: None]              │
+│ --version                                               Show the application's       │
+│                                                         version                      │
+│ --install-completion                                    Install completion for the   │
+│                                                         current shell.               │
+│ --show-completion                                       Show completion for the      │
+│                                                         current shell, to copy it or │
+│                                                         customize the installation.  │
+│ --help                                                  Show this message and exit.  │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -177,6 +187,11 @@ uv-secure can read configuration from a toml file specified with the config opti
 ### uv-secure.toml / .uv-secure.toml
 
 ```toml
+[ignore_packages]
+requests = [] # Ignore issues with all versions of the requests package
+urllib = [">=1.0, <2.0"] # Ignore issues between version 1.0 and less than 2.0
+jinja2 = [">=0.1, <1.0", "~=2.0"] # Ignore issues between version 0.1 and 1.0 or 2.0
+
 [vulnerability_criteria]
 ignore_vulnerabilities = ["VULN-123"]
 aliases = true # Defaults to false
@@ -192,6 +207,11 @@ forbid_yanked = true # Defaults to false (allow yanked package dependencies) if 
 ### pyproject.toml
 
 ```toml
+[tool.uv-secure.ignore_packages]
+requests = [] # Ignore issues with all versions of the requests package
+urllib = [">=1.0, <2.0"] # Ignore issues between version 1.0 and less than 2.0
+jinja2 = [">=0.1, <1.0", "~=2.0"] # Ignore issues between version 0.1 and 1.0 or 2.0
+
 [tool.uv-secure.vulnerability_criteria]
 ignore_vulnerabilities = ["VULN-123"]
 aliases = true # Defaults to false
@@ -251,7 +271,7 @@ pyproject.toml files with uv-secure config (only if you define all three in the 
 directory though - which would be a bit weird - I may make this a warning or error in
 future).
 
-Like Ruff configuration files aren't hierarchically combined, just the nearest / highest
+Like Ruff, configuration files aren't hierarchically combined, the nearest / highest
 precedence configuration is used. If you set a specific configuration file that will
 take precedence and hierarchical configuration file discovery is disabled. If you do
 specify a configuration options directly, e.g. pass the  --ignore option that will
@@ -265,7 +285,7 @@ uv-secure can be run as a pre-commit hook by adding this configuration to your
 
 ```yaml
   - repo: https://github.com/owenlamont/uv-secure
-    rev: 0.10.0
+    rev: 0.11.0
     hooks:
       - id: uv-secure
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "uv-secure"
-dynamic = ["version"]
+version = "0.11.0"
 description = "Scan your uv.lock file for dependencies with known vulnerabilities"
 readme = "README.md"
 authors = [
     { name = "Owen Lamont", email = "owenrlamont@gmail.com" }
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = [
   "uv", "uv.lock", "vulnerabilities"
 ]
@@ -18,7 +18,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -36,6 +35,7 @@ dependencies = [
     "httpx>=0.28.1",
     "humanize>=4.11.0",
     "inflect>=7.4.0",
+    "packaging>=25.0",
     "pydantic[email]>=2.10.3",
     "rich>=13.9.4",
     "tomli; python_version < '3.11'",
@@ -56,8 +56,8 @@ Repository = "https://github.com/owenlamont/uv-secure"
 Releases = "https://github.com/owenlamont/uv-secure/releases"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.7.19,<0.8.0"]
+build-backend = "uv_build"
 
 [tool.coverage.paths]
 source = [
@@ -83,7 +83,7 @@ plugins = [
   "pydantic.mypy"
 ]
 
-python_version = "3.9"
+python_version = "3.10"
 files = ["src"]
 
 ignore_missing_imports = true

--- a/src/uv_secure/__init__.py
+++ b/src/uv_secure/__init__.py
@@ -1,5 +1,7 @@
-from uv_secure.__version__ import __version__
+from importlib.metadata import version
+
 from uv_secure.run import app
 
 
-__all__ = ["__version__", "app"]
+__all__ = ["app"]
+__version__ = version(__name__)

--- a/src/uv_secure/__version__.py
+++ b/src/uv_secure/__version__.py
@@ -1,1 +1,4 @@
-__version__ = "0.10.1"
+from importlib.metadata import version
+
+
+__version__ = version("uv_secure")

--- a/src/uv_secure/configuration/config_factory.py
+++ b/src/uv_secure/configuration/config_factory.py
@@ -34,17 +34,15 @@ def _parse_pkg_versions(raw: list[str] | None) -> dict[str, tuple[str, ...]] | N
     typer.BadParameter
         If the input format is invalid, e.g. missing colon or no specifiers
     """
+    if not raw:
+        return None
     parsed: dict[str, tuple[str, ...]] = {}
-    if raw is None:
-        return parsed
     for item in raw:
         if ":" in item:
             name, spec_expr = item.split(":", 1)
             parsed[name] = tuple(spec_expr.split("|"))
         else:
             parsed[item] = ()
-    if not parsed:
-        return None
     return parsed
 
 

--- a/src/uv_secure/configuration/config_factory.py
+++ b/src/uv_secure/configuration/config_factory.py
@@ -20,19 +20,15 @@ def _parse_pkg_versions(raw: list[str] | None) -> dict[str, tuple[str, ...]] | N
     Parse things like "foo:>=1.0,<1.5|==4.5.*" into
     {"foo": [SpecifierSet(">=1.0,<1.5"), SpecifierSet("==4.5.*")]}
 
-    Parameters
-    ----------
-    raw
-        list of strings in the format "NAME:SPEC1|SPEC2|…"
+    Args:
+        raw: list of strings in the format "NAME:SPEC1|SPEC2|…"
 
-    Returns
-    -------
+    Returns:
         dictionary mapping package names to lists of SpecifierSets
 
-    Raises
-    ------
-    typer.BadParameter
-        If the input format is invalid, e.g. missing colon or no specifiers
+    Raises:
+        typer.BadParameter: If the input format is invalid, e.g. missing colon or no
+        specifiers
     """
     if not raw:
         return None
@@ -67,8 +63,7 @@ def config_cli_arg_factory(
         ignore_vulns: comma separated string of vulnerability ids to ignore
         ignore_pkgs: list of package names and version specifiers to ignore
 
-    Returns
-    -------
+    Returns:
         uv-secure override configuration object
     """
     ignore_vulnerabilities = (
@@ -94,10 +89,9 @@ async def config_file_factory(config_file: Path) -> Configuration | None:
 
     Args:
         config_file: Path to the configuration file (uv-secure.toml, .uv-secure.toml, or
-        pyproject.toml)
+            pyproject.toml)
 
-    Returns
-    -------
+    Returns:
         uv-secure configuration object or None if no configuration was present
     """
     try:

--- a/src/uv_secure/configuration/config_factory.py
+++ b/src/uv_secure/configuration/config_factory.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 import sys
-from typing import Optional
 
 from anyio import Path
 from pydantic import ValidationError
@@ -15,14 +14,49 @@ else:
     import tomli as toml
 
 
+def _parse_pkg_versions(raw: list[str] | None) -> dict[str, tuple[str, ...]] | None:
+    """Parse package and bar delimited version specifiers
+
+    Parse things like "foo:>=1.0,<1.5|==4.5.*" into
+    {"foo": [SpecifierSet(">=1.0,<1.5"), SpecifierSet("==4.5.*")]}
+
+    Parameters
+    ----------
+    raw
+        list of strings in the format "NAME:SPEC1|SPEC2|…"
+
+    Returns
+    -------
+        dictionary mapping package names to lists of SpecifierSets
+
+    Raises
+    ------
+    typer.BadParameter
+        If the input format is invalid, e.g. missing colon or no specifiers
+    """
+    parsed: dict[str, tuple[str, ...]] = {}
+    if raw is None:
+        return parsed
+    for item in raw:
+        if ":" in item:
+            name, spec_expr = item.split(":", 1)
+            parsed[name] = tuple(spec_expr.split("|"))
+        else:
+            parsed[item] = ()
+    if not parsed:
+        return None
+    return parsed
+
+
 def config_cli_arg_factory(
-    aliases: Optional[bool],
-    check_direct_dependency_maintenance_issues_only: Optional[bool],
-    check_direct_dependency_vulnerabilities_only: Optional[bool],
-    desc: Optional[bool],
-    forbid_yanked: Optional[bool],
-    max_package_age: Optional[int],
-    ignore: Optional[str],
+    aliases: bool | None,
+    check_direct_dependency_maintenance_issues_only: bool | None,
+    check_direct_dependency_vulnerabilities_only: bool | None,
+    desc: bool | None,
+    forbid_yanked: bool | None,
+    max_package_age: int | None,
+    ignore_vulns: str | None,
+    ignore_pkgs: list[str] | None,
 ) -> OverrideConfiguration:
     """Factory to create a uv-secure configuration from its command line arguments
 
@@ -32,15 +66,16 @@ def config_cli_arg_factory(
         disable_cache: Flag whether to disable cache
         forbid_yanked: flag whether to forbid yanked dependencies
         max_package_age: maximum age of dependencies in days
-        ignore: comma separated string of vulnerability ids to ignore
+        ignore_vulns: comma separated string of vulnerability ids to ignore
+        ignore_pkgs: list of package names and version specifiers to ignore
 
     Returns
     -------
         uv-secure override configuration object
     """
     ignore_vulnerabilities = (
-        {vuln_id.strip() for vuln_id in ignore.split(",") if vuln_id.strip()}
-        if ignore is not None
+        {vuln_id.strip() for vuln_id in ignore_vulns.split(",") if vuln_id.strip()}
+        if ignore_vulns is not None
         else None
     )
 
@@ -52,10 +87,11 @@ def config_cli_arg_factory(
         forbid_yanked=forbid_yanked,
         max_package_age=timedelta(days=max_package_age) if max_package_age else None,
         ignore_vulnerabilities=ignore_vulnerabilities,
+        ignore_packages=_parse_pkg_versions(ignore_pkgs),
     )
 
 
-async def config_file_factory(config_file: Path) -> Optional[Configuration]:
+async def config_file_factory(config_file: Path) -> Configuration | None:
     """Factory to create a uv-secure configuration from a configuration toml file
 
     Args:

--- a/src/uv_secure/configuration/configuration.py
+++ b/src/uv_secure/configuration/configuration.py
@@ -1,12 +1,11 @@
 from datetime import timedelta
-from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
 
 
 class MaintainabilityCriteria(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    max_package_age: Optional[timedelta] = None
+    max_package_age: timedelta | None = None
     forbid_yanked: bool = False
     check_direct_dependencies_only: bool = False
 
@@ -15,7 +14,7 @@ class VulnerabilityCriteria(BaseModel):
     model_config = ConfigDict(extra="forbid")
     aliases: bool = False
     desc: bool = False
-    ignore_vulnerabilities: Optional[set[str]] = None
+    ignore_vulnerabilities: set[str] | None = None
     check_direct_dependencies_only: bool = False
 
 
@@ -23,16 +22,18 @@ class Configuration(BaseModel):
     model_config = ConfigDict(extra="forbid")
     maintainability_criteria: MaintainabilityCriteria = MaintainabilityCriteria()
     vulnerability_criteria: VulnerabilityCriteria = VulnerabilityCriteria()
+    ignore_packages: dict[str, tuple[str, ...]] | None = None
 
 
 class OverrideConfiguration(BaseModel):
-    aliases: Optional[bool] = None
-    check_direct_dependency_maintenance_issues_only: Optional[bool] = None
-    check_direct_dependency_vulnerabilities_only: Optional[bool] = None
-    desc: Optional[bool] = None
-    ignore_vulnerabilities: Optional[set[str]] = None
-    forbid_yanked: Optional[bool] = None
-    max_package_age: Optional[timedelta] = None
+    aliases: bool | None = None
+    check_direct_dependency_maintenance_issues_only: bool | None = None
+    check_direct_dependency_vulnerabilities_only: bool | None = None
+    desc: bool | None = None
+    ignore_vulnerabilities: set[str] | None = None
+    ignore_packages: dict[str, tuple[str, ...]] | None = None
+    forbid_yanked: bool | None = None
+    max_package_age: timedelta | None = None
 
 
 def override_config(
@@ -65,6 +66,8 @@ def override_config(
         new_configuration.vulnerability_criteria.ignore_vulnerabilities = (
             overrides.ignore_vulnerabilities
         )
+    if overrides.ignore_packages is not None:
+        new_configuration.ignore_packages = overrides.ignore_packages
     if overrides.forbid_yanked is not None:
         new_configuration.maintainability_criteria.forbid_yanked = (
             overrides.forbid_yanked

--- a/src/uv_secure/dependency_checker/dependency_checker.py
+++ b/src/uv_secure/dependency_checker/dependency_checker.py
@@ -368,8 +368,7 @@ async def check_lock_files(
         config_path: path to configuration file
 
 
-    Returns
-    -------
+    Returns:
         True if vulnerabilities were found, False otherwise.
     """
     file_apaths: tuple[APath, ...] = (

--- a/src/uv_secure/directory_scanner/directory_scanner.py
+++ b/src/uv_secure/directory_scanner/directory_scanner.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable, Sequence
-from typing import Union
 
 from anyio import Path
 from asyncer import create_task_group
@@ -49,7 +48,7 @@ def _get_root_dir(file_paths: Sequence[Path]) -> Path:
 
 
 async def get_dependency_file_to_config_map(
-    file_paths: Union[Path, list[Path]],
+    file_paths: Path | Sequence[Path],
 ) -> dict[Path, Configuration]:
     """Get map of uv.lock files to their configurations.
 
@@ -99,7 +98,9 @@ async def get_dependency_file_to_config_map(
         ]
     configs = [future.value for future in config_futures]
     path_config_map = {
-        p.parent: c for p, c in zip(config_file_paths, configs) if c is not None
+        p.parent: c
+        for p, c in zip(config_file_paths, configs, strict=False)
+        if c is not None
     }
 
     dependency_file_paths = config_and_lock_files.get(

--- a/src/uv_secure/package_info/dependency_file_parser.py
+++ b/src/uv_secure/package_info/dependency_file_parser.py
@@ -1,5 +1,4 @@
 import sys
-from typing import Optional
 
 from anyio import Path
 from pydantic import BaseModel
@@ -33,7 +32,7 @@ async def parse_requirements_txt_file(file_path: Path) -> list[Dependency]:
         )
         return []
     dependencies = []
-    dependency: Optional[Dependency] = None
+    dependency: Dependency | None = None
     for line in lines:
         if "==" in line:
             if dependency is not None:

--- a/src/uv_secure/package_info/package_info_downloader.py
+++ b/src/uv_secure/package_info/package_info_downloader.py
@@ -1,7 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
 import re
-from typing import Optional, Union
 
 from hishel import AsyncCacheClient
 from pydantic import BaseModel
@@ -10,42 +9,42 @@ from uv_secure.package_info.dependency_file_parser import Dependency
 
 
 class Downloads(BaseModel):
-    last_day: Optional[int] = None
-    last_month: Optional[int] = None
-    last_week: Optional[int] = None
+    last_day: int | None = None
+    last_month: int | None = None
+    last_week: int | None = None
 
 
 class Info(BaseModel):
-    author: Optional[str] = None
-    author_email: Optional[str] = None
-    bugtrack_url: Optional[str] = None
+    author: str | None = None
+    author_email: str | None = None
+    bugtrack_url: str | None = None
     classifiers: list[str]
     description: str
-    description_content_type: Optional[str] = None
-    docs_url: Optional[str] = None
-    download_url: Optional[str] = None
+    description_content_type: str | None = None
+    docs_url: str | None = None
+    download_url: str | None = None
     downloads: Downloads
-    dynamic: Optional[Union[list[str], str]] = None
-    home_page: Optional[str] = None
-    keywords: Optional[Union[str, list[str]]] = None
-    license: Optional[str] = None
-    license_expression: Optional[str] = None
-    license_files: Optional[list[str]] = None
-    maintainer: Optional[str] = None
-    maintainer_email: Optional[str] = None
+    dynamic: list[str] | str | None = None
+    home_page: str | None = None
+    keywords: str | list[str] | None = None
+    license: str | None = None
+    license_expression: str | None = None
+    license_files: list[str] | None = None
+    maintainer: str | None = None
+    maintainer_email: str | None = None
     name: str
-    package_url: Optional[str] = None
-    platform: Optional[str] = None
-    project_url: Optional[str] = None
-    project_urls: Optional[dict[str, str]] = None
-    provides_extra: Optional[list[str]] = None
+    package_url: str | None = None
+    platform: str | None = None
+    project_url: str | None = None
+    project_urls: dict[str, str] | None = None
+    provides_extra: list[str] | None = None
     release_url: str
-    requires_dist: Optional[list[str]] = None
-    requires_python: Optional[str] = None
-    summary: Optional[str] = None
+    requires_dist: list[str] | None = None
+    requires_python: str | None = None
+    summary: str | None = None
     version: str
     yanked: bool
-    yanked_reason: Optional[str] = None
+    yanked_reason: str | None = None
 
 
 class Digests(BaseModel):
@@ -55,7 +54,7 @@ class Digests(BaseModel):
 
 
 class Url(BaseModel):
-    comment_text: Optional[str] = None
+    comment_text: str | None = None
     digests: Digests
     downloads: int
     filename: str
@@ -63,24 +62,24 @@ class Url(BaseModel):
     md5_digest: str
     packagetype: str
     python_version: str
-    requires_python: Optional[str] = None
+    requires_python: str | None = None
     size: int
     upload_time: datetime
     upload_time_iso_8601: datetime
     url: str
     yanked: bool
-    yanked_reason: Optional[str] = None
+    yanked_reason: str | None = None
 
 
 class Vulnerability(BaseModel):
     id: str
     details: str
-    fixed_in: Optional[list[str]] = None
-    aliases: Optional[list[str]] = None
-    link: Optional[str] = None
-    source: Optional[str] = None
-    summary: Optional[str] = None
-    withdrawn: Optional[str] = None
+    fixed_in: list[str] | None = None
+    aliases: list[str] | None = None
+    link: str | None = None
+    source: str | None = None
+    summary: str | None = None
+    withdrawn: str | None = None
 
 
 class PackageInfo(BaseModel):
@@ -91,7 +90,7 @@ class PackageInfo(BaseModel):
     direct_dependency: bool = False
 
     @property
-    def age(self) -> Optional[timedelta]:
+    def age(self) -> timedelta | None:
         """Return age of the package"""
         release_date = min(
             (url.upload_time_iso_8601 for url in self.urls), default=None
@@ -121,7 +120,7 @@ async def _download_package(
 
 async def download_packages(
     dependencies: list[Dependency], http_client: AsyncCacheClient, disable_cache: bool
-) -> list[Union[PackageInfo, BaseException]]:
+) -> list[PackageInfo | BaseException]:
     """Fetch vulnerabilities for all dependencies concurrently."""
     tasks = [_download_package(http_client, dep, disable_cache) for dep in dependencies]
     return await asyncio.gather(*tasks, return_exceptions=True)

--- a/src/uv_secure/run.py
+++ b/src/uv_secure/run.py
@@ -112,9 +112,9 @@ _version_option = typer.Option(
 _ignore_pkg_options = typer.Option(
     None,
     "--ignore-pkgs",
-    metavar="PKG:SPEC…",
+    metavar="PKG:SPEC1|SPEC2|…",
     help=(
-        "Dependency with OR-groups.  "
+        "Dependency with optional version specifiers. "
         "Syntax: name:spec1|spec2|…  "
         "e.g. foo:>=1.0,<1.5|==4.5.*"
     ),

--- a/src/uv_secure/run.py
+++ b/src/uv_secure/run.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 import sys
-from typing import Optional
 
 import typer
 
-from uv_secure.__version__ import __version__
+from uv_secure import __version__
 from uv_secure.dependency_checker import check_lock_files, RunStatus
 
 
@@ -86,10 +85,9 @@ _max_package_age_option = typer.Option(
     None, "--max-age-days", help="Maximum age threshold for packages in days"
 )
 
-_ignore_option = typer.Option(
+_ignore_vulns_option = typer.Option(
     None,
-    "--ignore",
-    "-i",
+    "--ignore-vulns",
     help="Comma-separated list of vulnerability IDs to ignore, e.g. VULN-123,VULN-456",
 )
 
@@ -111,24 +109,35 @@ _version_option = typer.Option(
 )
 
 
+_ignore_pkg_options = typer.Option(
+    None,
+    "--ignore-pkgs",
+    metavar="PKG:SPEC…",
+    help=(
+        "Dependency with OR-groups.  "
+        "Syntax: name:spec1|spec2|…  "
+        "e.g. foo:>=1.0,<1.5|==4.5.*"
+    ),
+)
+
+
 @app.command()
 def main(
-    file_paths: Optional[list[Path]] = _file_path_args,
-    aliases: Optional[bool] = _aliases_option,
-    desc: Optional[bool] = _desc_option,
+    file_paths: list[Path] | None = _file_path_args,
+    aliases: bool | None = _aliases_option,
+    desc: bool | None = _desc_option,
     cache_path: Path = _cache_path_option,
     cache_ttl_seconds: float = _cache_ttl_seconds_option,
     disable_cache: bool = _disable_cache_option,
-    forbid_yanked: Optional[bool] = _forbid_yanked_option,
-    max_package_age: Optional[int] = _max_package_age_option,
-    ignore: Optional[str] = _ignore_option,
-    check_direct_dependency_vulnerabilities_only: Optional[
-        bool
-    ] = _check_direct_dependency_vulnerabilities_only_option,
-    check_direct_dependency_maintenance_issues_only: Optional[
-        bool
-    ] = _check_direct_dependency_maintenance_issues_only_option,
-    config_path: Optional[Path] = _config_option,
+    forbid_yanked: bool | None = _forbid_yanked_option,
+    max_package_age: int | None = _max_package_age_option,
+    ignore_vulns: str | None = _ignore_vulns_option,
+    ignore_pkgs: list[str] | None = _ignore_pkg_options,
+    check_direct_dependency_vulnerabilities_only: bool
+    | None = _check_direct_dependency_vulnerabilities_only_option,
+    check_direct_dependency_maintenance_issues_only: bool
+    | None = _check_direct_dependency_maintenance_issues_only_option,
+    config_path: Path | None = _config_option,
     version: bool = _version_option,
 ) -> None:
     """Parse uv.lock files, check vulnerabilities, and display summary."""
@@ -152,7 +161,8 @@ def main(
             disable_cache,
             forbid_yanked,
             max_package_age,
-            ignore,
+            ignore_vulns,
+            ignore_pkgs,
             check_direct_dependency_vulnerabilities_only,
             check_direct_dependency_maintenance_issues_only,
             config_path,

--- a/tests/uv_secure/configuration/test_configuration_factory.py
+++ b/tests/uv_secure/configuration/test_configuration_factory.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional
 
 from anyio import Path as APath
 import pytest
@@ -50,7 +49,7 @@ async def test_check_dependencies_alias_hyperlinks(
     tmp_path: Path,
     filename: str,
     file_contents: str,
-    expected_configuration: Optional[Configuration],
+    expected_configuration: Configuration | None,
 ) -> None:
     config_file_path = tmp_path / filename
     config_file_path.write_text(dedent(file_contents).strip())

--- a/tests/uv_secure/conftest.py
+++ b/tests/uv_secure/conftest.py
@@ -1,7 +1,6 @@
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
 from textwrap import dedent
-from typing import Callable
 
 from httpx import Request, RequestError
 import pytest

--- a/tests/uv_secure/conftest.py
+++ b/tests/uv_secure/conftest.py
@@ -255,6 +255,17 @@ def temp_pyproject_toml_file_ignored_vulnerability(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def temp_pyproject_toml_file_ignored_package(tmp_path: Path) -> Path:
+    pyproject_toml_path = tmp_path / "pyproject.toml"
+    uv_lock_data = """
+    [tool.uv-secure.ignore_packages]
+    example-package = [">=1.0, <2.0"]
+    """
+    pyproject_toml_path.write_text(dedent(uv_lock_data).strip())
+    return pyproject_toml_path
+
+
+@pytest.fixture
 def temp_nested_pyproject_toml_file_no_config(tmp_path: Path) -> Path:
     pyproject_toml_path = tmp_path / "nested_project" / "pyproject.toml"
     uv_lock_data = ""

--- a/tests/uv_secure/conftest.py
+++ b/tests/uv_secure/conftest.py
@@ -120,7 +120,7 @@ def temp_uv_secure_toml_file_ignored_package(tmp_path: Path) -> Path:
     uv_secure_toml_path = tmp_path / "uv-secure.toml"
     uv_lock_data = """
         [ignore_packages]
-        example-package = [">=1.0, <2.0"]
+        example-package = []
     """
     uv_secure_toml_path.write_text(dedent(uv_lock_data).strip())
     return uv_secure_toml_path

--- a/tests/uv_secure/conftest.py
+++ b/tests/uv_secure/conftest.py
@@ -116,6 +116,17 @@ def temp_uv_secure_toml_file_ignored_vulnerability(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def temp_uv_secure_toml_file_ignored_package(tmp_path: Path) -> Path:
+    uv_secure_toml_path = tmp_path / "uv-secure.toml"
+    uv_lock_data = """
+        [ignore_packages]
+        example-package = [">=1.0, <2.0"]
+    """
+    uv_secure_toml_path.write_text(dedent(uv_lock_data).strip())
+    return uv_secure_toml_path
+
+
+@pytest.fixture
 def temp_uv_secure_toml_file_direct_dependency_vulnerabilities_only(
     tmp_path: Path,
 ) -> Path:

--- a/tests/uv_secure/test_run.py
+++ b/tests/uv_secure/test_run.py
@@ -517,6 +517,23 @@ def test_app_with_uv_secure_toml_ignored_vulnerability(
     assert "All dependencies appear safe!" in result.output
 
 
+def test_app_with_uv_secure_toml_ignored_package(
+    temp_uv_lock_file: Path,
+    temp_uv_secure_toml_file_ignored_package: Path,
+    one_vulnerability_response: HTTPXMock,
+) -> None:
+    result = runner.invoke(
+        app,
+        [str(temp_uv_lock_file), "--config", temp_uv_secure_toml_file_ignored_package],
+        "--disable-cache",
+    )
+
+    assert result.exit_code == 0
+    assert "No vulnerabilities or maintenance issues detected!" in result.output
+    assert "Checked: 1 dependency" in result.output
+    assert "All dependencies appear safe!" in result.output
+
+
 def test_app_with_pyproject_toml_ignored_vulnerability(
     temp_uv_lock_file: Path,
     temp_pyproject_toml_file_ignored_vulnerability: Path,
@@ -529,6 +546,23 @@ def test_app_with_pyproject_toml_ignored_vulnerability(
             "--config",
             temp_pyproject_toml_file_ignored_vulnerability,
         ],
+        "--disable-cache",
+    )
+
+    assert result.exit_code == 0
+    assert "No vulnerabilities or maintenance issues detected!" in result.output
+    assert "Checked: 1 dependency" in result.output
+    assert "All dependencies appear safe!" in result.output
+
+
+def test_app_with_pyproject_toml_ignored_package(
+    temp_uv_lock_file: Path,
+    temp_pyproject_toml_file_ignored_package: Path,
+    one_vulnerability_response: HTTPXMock,
+) -> None:
+    result = runner.invoke(
+        app,
+        [str(temp_uv_lock_file), "--config", temp_pyproject_toml_file_ignored_package],
         "--disable-cache",
     )
 

--- a/tests/uv_secure/test_run.py
+++ b/tests/uv_secure/test_run.py
@@ -323,6 +323,26 @@ def test_app_with_arg_ignored_package_with_specifiers(
     assert "All dependencies appear safe!" in result.output
 
 
+def test_app_with_arg_ignored_package_with_specifiers_no_match(
+    temp_uv_lock_file: Path, one_vulnerability_response: HTTPXMock
+) -> None:
+    result = runner.invoke(
+        app,
+        [
+            str(temp_uv_lock_file),
+            "--ignore-pkgs",
+            "example-package:>=0.5,<0.6",
+            "--disable-cache",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Vulnerabilities detected!" in result.output
+    assert "Checked: 1 dependency" in result.output
+    assert "Vulnerable: 1 vulnerability" in result.output
+    assert "example-package" in result.output
+
+
 def test_app_with_arg_withdrawn_vulnerability(
     temp_uv_lock_file: Path, withdrawn_vulnerability_response: HTTPXMock
 ) -> None:

--- a/tests/uv_secure/test_run.py
+++ b/tests/uv_secure/test_run.py
@@ -304,6 +304,25 @@ def test_app_with_arg_ignored_package_no_specifiers(
     assert "All dependencies appear safe!" in result.output
 
 
+def test_app_with_arg_ignored_package_with_specifiers(
+    temp_uv_lock_file: Path, one_vulnerability_response: HTTPXMock
+) -> None:
+    result = runner.invoke(
+        app,
+        [
+            str(temp_uv_lock_file),
+            "--ignore-pkgs",
+            "example-package:>=0.5,<0.6|>=1.0,<2",
+            "--disable-cache",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "No vulnerabilities or maintenance issues detected!" in result.output
+    assert "Checked: 1 dependency" in result.output
+    assert "All dependencies appear safe!" in result.output
+
+
 def test_app_with_arg_withdrawn_vulnerability(
     temp_uv_lock_file: Path, withdrawn_vulnerability_response: HTTPXMock
 ) -> None:
@@ -428,6 +447,36 @@ def test_check_dependencies_with_vulnerability_pyproject_toml_cli_argument_overr
             str(temp_uv_lock_file),
             "--ignore-vulns",
             "VULN-NOT-HERE",
+            "--aliases",
+            "--desc",
+        ],
+        "--disable-cache",
+    )
+
+    assert "Vulnerabilities detected!" in result.output
+    assert "Checked: 1 dependency" in result.output
+    assert "Vulnerable: 1 vulnerability" in result.output
+    assert "example-package" in result.output
+    assert "1.0.0" in result.output
+    assert "VULN-123" in result.output
+    assert "1.0.1" in result.output
+    assert "Aliases" in result.output
+    assert "CVE-2024-12345" in result.output
+    assert "Details" in result.output
+    assert "A critical vulnerability in example-package.  " in result.output
+
+
+def test_check_dependencies_with_vulnerability_pyproject_toml_cli_argument_pkg_override(
+    temp_uv_lock_file: Path,
+    temp_pyproject_toml_file_ignored_package: Path,
+    one_vulnerability_response: HTTPXMock,
+) -> None:
+    result = runner.invoke(
+        app,
+        [
+            str(temp_uv_lock_file),
+            "--ignore-pkgs",
+            "another-package",
             "--aliases",
             "--desc",
         ],

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.9"
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version < '3.10'",
-]
+requires-python = ">=3.10"
 
 [[package]]
 name = "annotated-types"
@@ -36,7 +32,6 @@ version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/67/7ea59c3e69eaeee42e7fc91a5be67ca5849c8979acac2b920249760c6af2/asyncer-0.0.8.tar.gz", hash = "sha256:a589d980f57e20efb07ed91d0dbe67f1d2fd343e7142c66d3a099f05c620739c", size = 18217, upload-time = "2024-08-24T23:15:36.449Z" }
 wheels = [
@@ -54,28 +49,10 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
-]
-
-[[package]]
-name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -151,16 +128,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/2e/af6b86f7c95441ce82f035b3affe1cd147f727bbd92f563be35e2d585683/coverage-7.9.2-cp313-cp313t-win32.whl", hash = "sha256:1df6b76e737c6a92210eebcb2390af59a141f9e9430210595251fbaf02d46926", size = 215440, upload-time = "2025-07-03T10:53:52.808Z" },
     { url = "https://files.pythonhosted.org/packages/4d/bb/8a785d91b308867f6b2e36e41c569b367c00b70c17f54b13ac29bcd2d8c8/coverage-7.9.2-cp313-cp313t-win_amd64.whl", hash = "sha256:f5fd54310b92741ebe00d9c0d1d7b2b27463952c022da6d47c175d246a98d1bd", size = 216537, upload-time = "2025-07-03T10:53:54.273Z" },
     { url = "https://files.pythonhosted.org/packages/1d/a0/a6bffb5e0f41a47279fd45a8f3155bf193f77990ae1c30f9c224b61cacb0/coverage-7.9.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c48c2375287108c887ee87d13b4070a381c6537d30e8487b24ec721bf2a781cb", size = 214398, upload-time = "2025-07-03T10:53:56.715Z" },
-    { url = "https://files.pythonhosted.org/packages/62/ab/b4b06662ccaa00ca7bbee967b7035a33a58b41efb92d8c89a6c523a2ccd5/coverage-7.9.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ddc39510ac922a5c4c27849b739f875d3e1d9e590d1e7b64c98dadf037a16cce", size = 212037, upload-time = "2025-07-03T10:53:58.055Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/5e/04619995657acc898d15bfad42b510344b3a74d4d5bc34f2e279d46c781c/coverage-7.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a535c0c7364acd55229749c2b3e5eebf141865de3a8f697076a3291985f02d30", size = 212412, upload-time = "2025-07-03T10:53:59.451Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e7/1465710224dc6d31c534e7714cbd907210622a044adc81c810e72eea873f/coverage-7.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df0f9ef28e0f20c767ccdccfc5ae5f83a6f4a2fbdfbcbcc8487a8a78771168c8", size = 241164, upload-time = "2025-07-03T10:54:00.852Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/f2/44c6fbd2794afeb9ab6c0a14d3c088ab1dae3dff3df2624609981237bbb4/coverage-7.9.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f3da12e0ccbcb348969221d29441ac714bbddc4d74e13923d3d5a7a0bebef7a", size = 239032, upload-time = "2025-07-03T10:54:02.25Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d2/7a79845429c0aa2e6788bc45c26a2e3052fa91082c9ea1dea56fb531952c/coverage-7.9.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a17eaf46f56ae0f870f14a3cbc2e4632fe3771eab7f687eda1ee59b73d09fe4", size = 240148, upload-time = "2025-07-03T10:54:03.618Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/7d/2731d1b4c9c672d82d30d218224dfc62939cf3800bc8aba0258fefb191f5/coverage-7.9.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:669135a9d25df55d1ed56a11bf555f37c922cf08d80799d4f65d77d7d6123fcf", size = 239875, upload-time = "2025-07-03T10:54:05.022Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/83/685958715429a9da09cf172c15750ca5c795dd7259466f2645403696557b/coverage-7.9.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9d3a700304d01a627df9db4322dc082a0ce1e8fc74ac238e2af39ced4c083193", size = 238127, upload-time = "2025-07-03T10:54:06.366Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ff/161a4313308b3783126790adfae1970adbe4886fda8788792e435249910a/coverage-7.9.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:71ae8b53855644a0b1579d4041304ddc9995c7b21c8a1f16753c4d8903b4dfed", size = 239064, upload-time = "2025-07-03T10:54:07.878Z" },
-    { url = "https://files.pythonhosted.org/packages/17/14/fe33f41b2e80811021de059621f44c01ebe4d6b08bdb82d54a514488e933/coverage-7.9.2-cp39-cp39-win32.whl", hash = "sha256:dd7a57b33b5cf27acb491e890720af45db05589a80c1ffc798462a765be6d4d7", size = 214522, upload-time = "2025-07-03T10:54:09.331Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/30/63d850ec31b5c6f6a7b4e853016375b846258300320eda29376e2786ceeb/coverage-7.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:f65bb452e579d5540c8b37ec105dd54d8b9307b07bcaa186818c104ffda22441", size = 215419, upload-time = "2025-07-03T10:54:10.681Z" },
     { url = "https://files.pythonhosted.org/packages/d7/85/f8bbefac27d286386961c25515431482a425967e23d3698b75a250872924/coverage-7.9.2-pp39.pp310.pp311-none-any.whl", hash = "sha256:8a1166db2fb62473285bcb092f586e081e92656c7dfa8e9f62b4d39d7e6b5050", size = 204013, upload-time = "2025-07-03T10:54:12.084Z" },
     { url = "https://files.pythonhosted.org/packages/3c/38/bbe2e63902847cf79036ecc75550d0698af31c91c7575352eb25190d0fb3/coverage-7.9.2-py3-none-any.whl", hash = "sha256:e425cd5b00f6fc0ed7cdbd766c70be8baab4b7839e4d4fe5fac48581dd968ea4", size = 204005, upload-time = "2025-07-03T10:54:13.491Z" },
 ]
@@ -281,18 +248,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
 ]
 
 [[package]]
@@ -461,19 +416,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
     { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
     { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
-    { url = "https://files.pythonhosted.org/packages/53/ea/bbe9095cdd771987d13c82d104a9c8559ae9aec1e29f139e286fd2e9256e/pydantic_core-2.33.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a2b911a5b90e0374d03813674bf0a5fbbb7741570dcd4b4e85a2e48d17def29d", size = 2028677, upload-time = "2025-04-23T18:32:27.227Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1d/4ac5ed228078737d457a609013e8f7edc64adc37b91d619ea965758369e5/pydantic_core-2.33.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6fa6dfc3e4d1f734a34710f391ae822e0a8eb8559a85c6979e14e65ee6ba2954", size = 1864735, upload-time = "2025-04-23T18:32:29.019Z" },
-    { url = "https://files.pythonhosted.org/packages/23/9a/2e70d6388d7cda488ae38f57bc2f7b03ee442fbcf0d75d848304ac7e405b/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c54c939ee22dc8e2d545da79fc5381f1c020d6d3141d3bd747eab59164dc89fb", size = 1898467, upload-time = "2025-04-23T18:32:31.119Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/2e/1568934feb43370c1ffb78a77f0baaa5a8b6897513e7a91051af707ffdc4/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53a57d2ed685940a504248187d5685e49eb5eef0f696853647bf37c418c538f7", size = 1983041, upload-time = "2025-04-23T18:32:33.655Z" },
-    { url = "https://files.pythonhosted.org/packages/01/1a/1a1118f38ab64eac2f6269eb8c120ab915be30e387bb561e3af904b12499/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09fb9dd6571aacd023fe6aaca316bd01cf60ab27240d7eb39ebd66a3a15293b4", size = 2136503, upload-time = "2025-04-23T18:32:35.519Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/da/44754d1d7ae0f22d6d3ce6c6b1486fc07ac2c524ed8f6eca636e2e1ee49b/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e6116757f7959a712db11f3e9c0a99ade00a5bbedae83cb801985aa154f071b", size = 2736079, upload-time = "2025-04-23T18:32:37.659Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/98/f43cd89172220ec5aa86654967b22d862146bc4d736b1350b4c41e7c9c03/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d55ab81c57b8ff8548c3e4947f119551253f4e3787a7bbc0b6b3ca47498a9d3", size = 2006508, upload-time = "2025-04-23T18:32:39.637Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/cc/f77e8e242171d2158309f830f7d5d07e0531b756106f36bc18712dc439df/pydantic_core-2.33.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c20c462aa4434b33a2661701b861604913f912254e441ab8d78d30485736115a", size = 2113693, upload-time = "2025-04-23T18:32:41.818Z" },
-    { url = "https://files.pythonhosted.org/packages/54/7a/7be6a7bd43e0a47c147ba7fbf124fe8aaf1200bc587da925509641113b2d/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:44857c3227d3fb5e753d5fe4a3420d6376fa594b07b621e220cd93703fe21782", size = 2074224, upload-time = "2025-04-23T18:32:44.033Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/07/31cf8fadffbb03be1cb520850e00a8490c0927ec456e8293cafda0726184/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:eb9b459ca4df0e5c87deb59d37377461a538852765293f9e6ee834f0435a93b9", size = 2245403, upload-time = "2025-04-23T18:32:45.836Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/8d/bbaf4c6721b668d44f01861f297eb01c9b35f612f6b8e14173cb204e6240/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9fcd347d2cc5c23b06de6d3b7b8275be558a0c90549495c699e379a80bf8379e", size = 2242331, upload-time = "2025-04-23T18:32:47.618Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/93/3cc157026bca8f5006250e74515119fcaa6d6858aceee8f67ab6dc548c16/pydantic_core-2.33.2-cp39-cp39-win32.whl", hash = "sha256:83aa99b1285bc8f038941ddf598501a86f1536789740991d7d8756e34f1e74d9", size = 1910571, upload-time = "2025-04-23T18:32:49.401Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/90/7edc3b2a0d9f0dda8806c04e511a67b0b7a41d2187e2003673a996fb4310/pydantic_core-2.33.2-cp39-cp39-win_amd64.whl", hash = "sha256:f481959862f57f29601ccced557cc2e817bce7533ab8e01a797a48b49c9692b3", size = 1956504, upload-time = "2025-04-23T18:32:51.287Z" },
     { url = "https://files.pythonhosted.org/packages/30/68/373d55e58b7e83ce371691f6eaa7175e3a24b956c44628eb25d7da007917/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c4aa4e82353f65e548c476b37e64189783aa5384903bfea4f41580f255fddfa", size = 2023982, upload-time = "2025-04-23T18:32:53.14Z" },
     { url = "https://files.pythonhosted.org/packages/a4/16/145f54ac08c96a63d8ed6442f9dec17b2773d19920b627b18d4f10a061ea/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d946c8bf0d5c24bf4fe333af284c59a19358aa3ec18cb3dc4370080da1e8ad29", size = 1858412, upload-time = "2025-04-23T18:32:55.52Z" },
     { url = "https://files.pythonhosted.org/packages/41/b1/c6dc6c3e2de4516c0bb2c46f6a373b91b5660312342a0cf5826e38ad82fa/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b31b6846e361ef83fedb187bb5b4372d0da3f7e28d85415efa92d6125d6e6d", size = 1892749, upload-time = "2025-04-23T18:32:57.546Z" },
@@ -492,15 +434,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013, upload-time = "2025-04-23T18:33:26.621Z" },
     { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715, upload-time = "2025-04-23T18:33:28.656Z" },
     { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757, upload-time = "2025-04-23T18:33:30.645Z" },
-    { url = "https://files.pythonhosted.org/packages/08/98/dbf3fdfabaf81cda5622154fda78ea9965ac467e3239078e0dcd6df159e7/pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:87acbfcf8e90ca885206e98359d7dca4bcbb35abdc0ff66672a293e1d7a19101", size = 2024034, upload-time = "2025-04-23T18:33:32.843Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/99/7810aa9256e7f2ccd492590f86b79d370df1e9292f1f80b000b6a75bd2fb/pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f92c15cd1e97d4b12acd1cc9004fa092578acfa57b67ad5e43a197175d01a64", size = 1858578, upload-time = "2025-04-23T18:33:34.912Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/60/bc06fa9027c7006cc6dd21e48dbf39076dc39d9abbaf718a1604973a9670/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f26877a748dc4251cfcfda9dfb5f13fcb034f5308388066bcfe9031b63ae7d", size = 1892858, upload-time = "2025-04-23T18:33:36.933Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/40/9d03997d9518816c68b4dfccb88969756b9146031b61cd37f781c74c9b6a/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac89aea9af8cd672fa7b510e7b8c33b0bba9a43186680550ccf23020f32d535", size = 2068498, upload-time = "2025-04-23T18:33:38.997Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/62/d490198d05d2d86672dc269f52579cad7261ced64c2df213d5c16e0aecb1/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:970919794d126ba8645f3837ab6046fb4e72bbc057b3709144066204c19a455d", size = 2108428, upload-time = "2025-04-23T18:33:41.18Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/ec/4cd215534fd10b8549015f12ea650a1a973da20ce46430b68fc3185573e8/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3eb3fe62804e8f859c49ed20a8451342de53ed764150cb14ca71357c765dc2a6", size = 2069854, upload-time = "2025-04-23T18:33:43.446Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/1a/abbd63d47e1d9b0d632fee6bb15785d0889c8a6e0a6c3b5a8e28ac1ec5d2/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:3abcd9392a36025e3bd55f9bd38d908bd17962cc49bc6da8e7e96285336e2bca", size = 2237859, upload-time = "2025-04-23T18:33:45.56Z" },
-    { url = "https://files.pythonhosted.org/packages/80/1c/fa883643429908b1c90598fd2642af8839efd1d835b65af1f75fba4d94fe/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:3a1c81334778f9e3af2f8aeb7a960736e5cab1dfebfb26aabca09afd2906c039", size = 2239059, upload-time = "2025-04-23T18:33:47.735Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/29/3cade8a924a61f60ccfa10842f75eb12787e1440e2b8660ceffeb26685e7/pydantic_core-2.33.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2807668ba86cb38c6817ad9bc66215ab8584d1d304030ce4f0887336f28a5e27", size = 2066661, upload-time = "2025-04-23T18:33:49.995Z" },
 ]
 
 [[package]]
@@ -536,7 +469,6 @@ version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
 wheels = [
@@ -688,7 +620,6 @@ name = "typeguard"
 version = "4.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/68/71c1a15b5f65f40e91b65da23b8224dad41349894535a97f63a52e462196/typeguard-4.4.4.tar.gz", hash = "sha256:3a7fd2dffb705d4d0efaed4306a704c89b9dee850b688f060a8b1615a79e5f74", size = 75203, upload-time = "2025-06-18T09:56:07.624Z" }
@@ -701,8 +632,7 @@ name = "typer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
     { name = "typing-extensions" },
@@ -714,11 +644,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.0"
+version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423, upload-time = "2025-06-02T14:52:11.399Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839, upload-time = "2025-06-02T14:52:10.026Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
 ]
 
 [[package]]
@@ -735,6 +665,7 @@ wheels = [
 
 [[package]]
 name = "uv-secure"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -743,6 +674,7 @@ dependencies = [
     { name = "httpx" },
     { name = "humanize" },
     { name = "inflect" },
+    { name = "packaging" },
     { name = "pydantic", extra = ["email"] },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -776,6 +708,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "humanize", specifier = ">=4.11.0" },
     { name = "inflect", specifier = ">=7.4.0" },
+    { name = "packaging", specifier = ">=25.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.3" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -828,12 +761,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/19/f5b78616566ea68edd42aacaf645adbf71fbd83fc52281fba555dc27e3f1/uvloop-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3df876acd7ec037a3d005b3ab85a7e4110422e4d9c1571d4fc89b0fc41b6816", size = 4701068, upload-time = "2024-10-14T23:38:06.385Z" },
     { url = "https://files.pythonhosted.org/packages/47/57/66f061ee118f413cd22a656de622925097170b9380b30091b78ea0c6ea75/uvloop-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd53ecc9a0f3d87ab847503c2e1552b690362e005ab54e8a48ba97da3924c0dc", size = 4454428, upload-time = "2024-10-14T23:38:08.416Z" },
     { url = "https://files.pythonhosted.org/packages/63/9a/0962b05b308494e3202d3f794a6e85abe471fe3cafdbcf95c2e8c713aabd/uvloop-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5c39f217ab3c663dc699c04cbd50c13813e31d917642d459fdcec07555cc553", size = 4660018, upload-time = "2024-10-14T23:38:10.888Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a4/646a9d0edff7cde25fc1734695d3dfcee0501140dd0e723e4df3f0a50acb/uvloop-0.21.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c097078b8031190c934ed0ebfee8cc5f9ba9642e6eb88322b9958b649750f72b", size = 1439646, upload-time = "2024-10-14T23:38:24.656Z" },
-    { url = "https://files.pythonhosted.org/packages/01/2e/e128c66106af9728f86ebfeeb52af27ecd3cb09336f3e2f3e06053707a15/uvloop-0.21.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:46923b0b5ee7fc0020bef24afe7836cb068f5050ca04caf6b487c513dc1a20b2", size = 800931, upload-time = "2024-10-14T23:38:26.087Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/1a/9fbc2b1543d0df11f7aed1632f64bdf5ecc4053cf98cdc9edb91a65494f9/uvloop-0.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53e420a3afe22cdcf2a0f4846e377d16e718bc70103d7088a4f7623567ba5fb0", size = 3829660, upload-time = "2024-10-14T23:38:27.905Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c0/392e235e4100ae3b95b5c6dac77f82b529d2760942b1e7e0981e5d8e895d/uvloop-0.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88cb67cdbc0e483da00af0b2c3cdad4b7c61ceb1ee0f33fe00e09c81e3a6cb75", size = 3827185, upload-time = "2024-10-14T23:38:29.458Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/24/a5da6aba58f99aed5255eca87d58d1760853e8302d390820cc29058408e3/uvloop-0.21.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:221f4f2a1f46032b403bf3be628011caf75428ee3cc204a22addf96f586b19fd", size = 3705833, upload-time = "2024-10-14T23:38:31.155Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/5c/6ba221bb60f1e6474474102e17e38612ec7a06dc320e22b687ab563d877f/uvloop-0.21.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2d1f581393673ce119355d56da84fe1dd9d2bb8b3d13ce792524e1607139feff", size = 3804696, upload-time = "2024-10-14T23:38:33.633Z" },
 ]
 
 [[package]]
@@ -846,14 +773,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/e5/d8e4b50057e1472b05543235a6fc55b789b3ebb28bedb567cfe228a067be/winloop-0.1.8-cp311-cp311-win_amd64.whl", hash = "sha256:d2bbcd6fc2e3eb6b0e15b9641fd1fb80a2e573c9601689ad108815ce1cdaf9bf", size = 706256, upload-time = "2025-01-13T23:01:47.756Z" },
     { url = "https://files.pythonhosted.org/packages/4b/e6/adf5bdba2fe893a0a9d968801b5e8096b3cc1a7b7dc45beeda2fe61692a4/winloop-0.1.8-cp312-cp312-win_amd64.whl", hash = "sha256:736a21489419369e2affdbc8f274bb0d56df318d58106fc8febf1002ffd450d7", size = 712357, upload-time = "2025-01-13T23:01:50.73Z" },
     { url = "https://files.pythonhosted.org/packages/fd/6a/5133b4da347bb2fd334320cacb36a8bd232af3ded2235cd085c0a2247274/winloop-0.1.8-cp313-cp313-win_amd64.whl", hash = "sha256:0c1c2d2087cb2c1b7defefed44bd875c9b040d46a32caa27d1847e06cb4e5f50", size = 712469, upload-time = "2025-01-13T23:01:53.483Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/67/43044130ed103d4f788ea8b6f6a2636d1fe86a2476e97aff353f1659ddb1/winloop-0.1.8-cp39-cp39-win_amd64.whl", hash = "sha256:c3599890716d229b2b657cf0893bd1c9c14833704529c17d8764bc058f64e598", size = 697045, upload-time = "2025-01-13T23:01:56.97Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
Adding new CLI and configuration option to ignore packages by name (and also optionally version specifiers) from being reported  for maintenance / vulnerability issues.

Made a breaking change to the old ignore CLI argument and configuration to clarify it is for vulnerabilities and raised minimum supported Python version to 3.10