### PR TITLE
Replace yamllint hook with ryl-pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,10 +71,10 @@ repos:
         additional_dependencies:
           # Remove once this PR is deployed
           - sniffio>=1.3.1
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.38.0
+  - repo: https://github.com/owenlamont/ryl-pre-commit
+    rev: v0.3.5
     hooks:
-      - id: yamllint
+      - id: ryl
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.22.0
     hooks:


### PR DESCRIPTION
Closes #213

Replaces the yamllint pre-commit hook with owenlamont/ryl-pre-commit (id: ryl).